### PR TITLE
Packaging kamaki deps into connector tarball.

### DIFF
--- a/python/pom.xml
+++ b/python/pom.xml
@@ -29,7 +29,10 @@
 
   <properties>
       <connector.package.dir>slipstream_okeanos</connector.package.dir>
-      <kamaki.version>0.13.3</kamaki.version>
+      <kamaki.version>0.13.4</kamaki.version>
+      <astakosclient.version>0.16</astakosclient.version>
+      <objpool.version>0.4</objpool.version>
+      <progress.version>1.2</progress.version>
   </properties>
 
   <modules>

--- a/python/tar/bundle.xml
+++ b/python/tar/bundle.xml
@@ -45,5 +45,35 @@
         <exclude>**/*.pyc</exclude>
       </excludes>
     </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/astakosclient</directory>
+      <outputDirectory>astakosclient</outputDirectory>
+      <includes>
+        <include>**/*</include>
+      </includes>
+      <excludes>
+        <exclude>**/*.pyc</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/objpool</directory>
+      <outputDirectory>objpool</outputDirectory>
+      <includes>
+        <include>**/*</include>
+      </includes>
+      <excludes>
+        <exclude>**/*.pyc</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/progress</directory>
+      <outputDirectory>progress</outputDirectory>
+      <includes>
+        <include>**/*</include>
+      </includes>
+      <excludes>
+        <exclude>**/*.pyc</exclude>
+      </excludes>
+    </fileSet>
   </fileSets>
 </assembly>

--- a/python/tar/pom.xml
+++ b/python/tar/pom.xml
@@ -56,13 +56,58 @@
         </executions>
       </plugin>
 
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+
+              <execution>
+                <id>get-kamaki</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>curl</executable>
+                  <arguments>
+                    <argument>-sSf</argument>
+                    <argument>-L</argument>
+                    <argument>-o</argument>
+                    <argument>${project.build.directory}/kamaki-${kamaki.version}.tar.gz</argument>
+                    <argument>https://pypi.python.org/packages/source/k/kamaki/kamaki-${kamaki.version}.tar.gz</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>unpack-kamaki</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <workingDirectory>${project.build.directory}</workingDirectory>
+                  <executable>tar</executable>
+                  <arguments>
+                    <argument>--strip-components</argument>
+                    <argument>1</argument>
+                    <argument>-zxvf</argument>
+                    <argument>kamaki-${kamaki.version}.tar.gz</argument>
+                    <argument>kamaki-${kamaki.version}/kamaki</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+
+            </executions>
+          </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <executions>
 
           <execution>
-            <id>get-kamaki</id>
+            <id>get-astakosclient</id>
             <phase>process-resources</phase>
             <goals>
               <goal>exec</goal>
@@ -73,14 +118,14 @@
                 <argument>-sSf</argument>
                 <argument>-L</argument>
                 <argument>-o</argument>
-                <argument>${project.build.directory}/kamaki-${kamaki.version}.tar.gz</argument>
-                <argument>https://pypi.python.org/packages/source/k/kamaki/kamaki-${kamaki.version}.tar.gz</argument>
+                <argument>${project.build.directory}/astakosclient-${astakosclient.version}.tar.gz</argument>
+                <argument>https://pypi.python.org/packages/source/a/astakosclient/astakosclient-${astakosclient.version}.tar.gz</argument>
               </arguments>
             </configuration>
           </execution>
 
           <execution>
-            <id>unpack-kamaki</id>
+            <id>unpack-astakosclient</id>
             <phase>process-resources</phase>
             <goals>
               <goal>exec</goal>
@@ -92,14 +137,105 @@
                 <argument>--strip-components</argument>
                 <argument>1</argument>
                 <argument>-zxvf</argument>
-                <argument>kamaki-${kamaki.version}.tar.gz</argument>
-                <argument>kamaki-${kamaki.version}/kamaki</argument>
+                <argument>astakosclient-${astakosclient.version}.tar.gz</argument>
+                <argument>astakosclient-${astakosclient.version}/astakosclient</argument>
               </arguments>
             </configuration>
           </execution>
 
         </executions>
       </plugin>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+
+              <execution>
+                <id>get-objpool</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>curl</executable>
+                  <arguments>
+                    <argument>-sSf</argument>
+                    <argument>-L</argument>
+                    <argument>-o</argument>
+                    <argument>${project.build.directory}/objpool-${objpool.version}.tar.gz</argument>
+                    <argument>https://pypi.python.org/packages/source/o/objpool/objpool-${objpool.version}.tar.gz</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>unpack-objpool</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <workingDirectory>${project.build.directory}</workingDirectory>
+                  <executable>tar</executable>
+                  <arguments>
+                    <argument>--strip-components</argument>
+                    <argument>1</argument>
+                    <argument>-zxvf</argument>
+                    <argument>objpool-${objpool.version}.tar.gz</argument>
+                    <argument>objpool-${objpool.version}/objpool</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+
+            </executions>
+          </plugin>
+
+          <!--https://pypi.python.org/packages/source/p/progress/progress-1.2.tar.gz-->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+
+              <execution>
+                <id>get-progress</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>curl</executable>
+                  <arguments>
+                    <argument>-sSf</argument>
+                    <argument>-L</argument>
+                    <argument>-o</argument>
+                    <argument>${project.build.directory}/progress-${progress.version}.tar.gz</argument>
+                    <argument>https://pypi.python.org/packages/source/p/progress/progress-${progress.version}.tar.gz</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>unpack-progress</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <workingDirectory>${project.build.directory}</workingDirectory>
+                  <executable>tar</executable>
+                  <arguments>
+                    <argument>--strip-components</argument>
+                    <argument>1</argument>
+                    <argument>-zxvf</argument>
+                    <argument>progress-${progress.version}.tar.gz</argument>
+                    <argument>progress-${progress.version}/progress</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+
+            </executions>
+          </plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/python/tar/pom.xml
+++ b/python/tar/pom.xml
@@ -191,7 +191,6 @@
             </executions>
           </plugin>
 
-          <!--https://pypi.python.org/packages/source/p/progress/progress-1.2.tar.gz-->
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>

--- a/python/tar/requirements.txt
+++ b/python/tar/requirements.txt
@@ -1,0 +1,8 @@
+kamaki==0.13.4
+# Full set of required packages for kamaki==0.13.4
+#astakosclient==0.16
+#objpool==0.4
+#progress==1.2
+#python-dateutil==2.4.2
+#six==1.9.0
+


### PR DESCRIPTION
When `kamaki` installs via `pip` the following gets pulled as the deps.

```
astakosclient==0.16
kamaki==0.13.4
objpool==0.4
progress==1.2
python-dateutil==2.4.2
six==1.9.0
```

It looks like `python-dateutil` and `six` are not required for the SS connector. `python-dateutil` (depends on `six`) and used in `kamaki.cli` only. Which I gather is not used in SS connector.

After packaging the tarball `SlipStreamConnector-Okeanos/python/tar/target/SlipStreamConnector-Okeanos-python-bundle-0.6.0-SNAPSHOT-bundle.tar.gz` contains the required Python packages

```
bin/okeanos-describe-instances
bin/okeanos-run-instances
bin/okeanos-terminate-instances
slipstream_okeanos/__init__.py
slipstream_okeanos/OkeanosClientCloud.py
slipstream_okeanos/OkeanosCommand.py
slipstream_okeanos/OkeanosDescribeInstancesCommand.py
slipstream_okeanos/OkeanosRunInstancesCommand.py
slipstream_okeanos/OkeanosTerminateInstancesCommand.py
kamaki/cli/
kamaki/cli/argument/
kamaki/cli/cmds/
kamaki/cli/cmdtree/
kamaki/cli/config/
kamaki/cli/contrib/
kamaki/cli/utils/
kamaki/clients/
kamaki/clients/astakos/
kamaki/clients/blockstorage/
kamaki/clients/compute/
kamaki/clients/cyclades/
kamaki/clients/image/
kamaki/clients/network/
kamaki/clients/pithos/
kamaki/clients/storage/
kamaki/clients/utils/
kamaki/__init__.py
kamaki/cli/__init__.py
kamaki/cli/argument/__init__.py
kamaki/cli/argument/test.py
kamaki/cli/cmds/__init__.py
kamaki/cli/cmds/astakos.py
kamaki/cli/cmds/blockstorage.py
kamaki/cli/cmds/config.py
kamaki/cli/cmds/cyclades.py
kamaki/cli/cmds/errors.py
kamaki/cli/cmds/history.py
kamaki/cli/cmds/image.py
kamaki/cli/cmds/network.py
kamaki/cli/cmds/pithos.py
kamaki/cli/cmdtree/__init__.py
kamaki/cli/cmdtree/test.py
kamaki/cli/config/__init__.py
kamaki/cli/config/test.py
kamaki/cli/contrib/__init__.py
kamaki/cli/contrib/scripts.py
kamaki/cli/errors.py
kamaki/cli/history.py
kamaki/cli/logger.py
kamaki/cli/one_cmd.py
kamaki/cli/shell.py
kamaki/cli/test.py
kamaki/cli/utils/__init__.py
kamaki/cli/utils/test.py
kamaki/clients/__init__.py
kamaki/clients/astakos/__init__.py
kamaki/clients/astakos/test.py
kamaki/clients/blockstorage/__init__.py
kamaki/clients/blockstorage/rest_api.py
kamaki/clients/blockstorage/test.py
kamaki/clients/compute/__init__.py
kamaki/clients/compute/rest_api.py
kamaki/clients/compute/test.py
kamaki/clients/cyclades/__init__.py
kamaki/clients/cyclades/rest_api.py
kamaki/clients/cyclades/test.py
kamaki/clients/image/__init__.py
kamaki/clients/image/test.py
kamaki/clients/network/__init__.py
kamaki/clients/network/rest_api.py
kamaki/clients/network/test.py
kamaki/clients/pithos/__init__.py
kamaki/clients/pithos/rest_api.py
kamaki/clients/pithos/test.py
kamaki/clients/storage/__init__.py
kamaki/clients/storage/test.py
kamaki/clients/test.py
kamaki/clients/utils/__init__.py
kamaki/clients/utils/https.py
kamaki/clients/utils/ordereddict.py
kamaki/clients/utils/test.py
kamaki/defaults.py
kamaki/version.py
astakosclient/__init__.py
astakosclient/errors.py
astakosclient/tests.py
astakosclient/utils.py
astakosclient/version.py
objpool/__init__.py
objpool/http.py
objpool/version.py
progress/__init__.py
progress/bar.py
progress/counter.py
progress/helpers.py
progress/spinner.py
```
